### PR TITLE
Migrate spring example from jersey to sse

### DIFF
--- a/sample-java-springboot/pom.xml
+++ b/sample-java-springboot/pom.xml
@@ -34,14 +34,8 @@
 		</dependency>
 		<dependency>
 			<groupId>io.featurehub.sdk</groupId>
-			<artifactId>java-client-jersey</artifactId>
-			<version>[2, 3)</version>
-		</dependency>
-		<!-- you would normally bring your own version of jersey and jackson dependencies -->
-		<dependency>
-			<groupId>io.featurehub.composites</groupId>
-			<artifactId>composite-jersey</artifactId>
-			<version>1.2</version>
+			<artifactId>java-client-sse</artifactId>
+			<version>1.4</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
In the java sdk repo you suggest to use SSE client for spring applications, however, the given example uses a jersey client. 
Jersey also gave me a lot of weird errors due to dependency mismatch when i tried using this example to try featurehub in an established spring project. 

I thus propose to migrate the spring example code from jersey to see. WDYT?